### PR TITLE
test: Add e2e test for global CSS

### DIFF
--- a/packages/next/server/require.ts
+++ b/packages/next/server/require.ts
@@ -69,7 +69,9 @@ export function requirePage(
   if (pagePath.endsWith('.html')) {
     return promises.readFile(pagePath, 'utf8')
   }
-  return require(pagePath)
+
+  // TODO Put CSS imports behind experimental flag
+  return safeRequire(pagePath)
 }
 
 export function requireFontManifest(distDir: string, serverless: boolean) {
@@ -123,5 +125,30 @@ export function getMiddlewareInfo(params: {
       ...binding,
       filePath: join(params.distDir, binding.filePath),
     })),
+  }
+}
+
+/**
+ * Safely load a module at the specified path, allowing for CSS imports by
+ * the requested module.
+ *
+ * @param path The path to the module to load.
+ * @param allowCssImports A flag to indicate that CSS imports are allowed.
+ */
+function safeRequire(path: string, allowCssImports: boolean = true): any {
+  let previous: any
+
+  if (allowCssImports) {
+    previous = require.extensions['.css']
+    // Make sure that we resolve CSS imports into empty objects on the server
+    require.extensions['.css'] = () => {}
+  }
+
+  try {
+    return require(path)
+  } finally {
+    if (allowCssImports) {
+      require.extensions['.css'] = previous
+    }
   }
 }

--- a/test/e2e/global-css/index.test.ts
+++ b/test/e2e/global-css/index.test.ts
@@ -1,0 +1,35 @@
+import { createNext } from 'e2e-utils'
+import { NextInstance } from 'test/lib/next-modes/base'
+import { renderViaHTTP } from 'next-test-utils'
+
+describe('global-css', () => {
+  let next: NextInstance
+
+  beforeAll(async () => {
+    next = await createNext({
+      files: {
+        'pages/index.js': `
+          import { Button } from '@patternfly/react-core';
+
+          export default function Page() { 
+            return <Button variant="primary">hello world</Button>
+          }
+        `,
+      },
+      nextConfig: {
+        experimental: {
+          craCompat: true,
+        },
+      },
+      dependencies: {
+        '@patternfly/react-core': '4.198.19',
+      },
+    })
+  })
+  afterAll(() => next.destroy())
+
+  it('should work', async () => {
+    const html = await renderViaHTTP(next.url, '/')
+    expect(html).toContain('hello world')
+  })
+})


### PR DESCRIPTION
This change adds a new e2e test that checks whether npm packages that
use CSS imports, such as PatternFly, can be used directly in Next.js,
without having to use a package like next-transpile-modules.

Currently, this functionality is not supported by Next.js, but this test
can serve as a regression test when it is introduced in a later version.